### PR TITLE
tenna: wrap with agent:vita-client to count user activity

### DIFF
--- a/desk/app/tenna.hoon
+++ b/desk/app/tenna.hoon
@@ -1,5 +1,5 @@
 /-  store=radio
-/+  radio
+/+  radio, vita-client
 /+  default-agent, dbug, verb, agentio
 =,  format
 :: ::
@@ -14,11 +14,13 @@
   ==
 +$  card     card:agent:gall
 --
-%+  verb  |
-%-  agent:dbug
 =|  state-0
 =*  state  -
 ^-  agent:gall
+%+  verb  |
+%-  agent:dbug
+%-  %-  agent:vita-client
+      [& ~nodmyn-dosrux]
 =<
 |_  =bowl:gall
 +*  this  .
@@ -164,7 +166,9 @@
   ?+    path
     (on-watch:def path)
       [%frontend ~]
-    `this
+    :_  this
+    :~  (active:vita-client bowl)
+    ==
   ==
 --
 :: ::


### PR DESCRIPTION
This is the full extent of integration into radio required for vita to collect daily active users.

This PR serves as documentation for developers wishing to use `vita-client`

Obviously you also need to pull in `/lib/vita-client.hoon` on the actual distributed desk. you way or may not that file in your actual repo. in this case, I dont.

I suggest your distr desk also includes the helper generators packaged with vita-client: `/gen/enable-vita.hoon` and `/gen/disable-vita.hoon` so that users can opt-in or opt-out more easily.